### PR TITLE
bugfix: ngx-accept-queue: fix max accept queue limit

### DIFF
--- a/ngx-accept-queue
+++ b/ngx-accept-queue
@@ -117,7 +117,7 @@ probe kernel.function("tcp_v4_conn_request") {
 
         if (max_syn_qlen == 0) {
             max_qlen_log = \@cast(\$sk, "struct inet_connection_sock")->icsk_accept_queue->listen_opt->max_qlen_log
-            max_syn_qlen = (2 << max_qlen_log)
+            max_syn_qlen = (1 << max_qlen_log)
             printf("SYN queue length limit: %d\\n", max_syn_qlen)
         }
 


### PR DESCRIPTION
I think the `max_syn_qlen` should be `1 << max_qlen_log`.
In kernel-2.6.18:

``` c
    for (lopt->max_qlen_log = 6;
         (1 << lopt->max_qlen_log) < sysctl_max_syn_backlog;
         lopt->max_qlen_log++);
```

In kernel-2.6.32:

``` c
   for (lopt->max_qlen_log = 3;
         (1 << lopt->max_qlen_log) < nr_table_entries;
         lopt->max_qlen_log++);
```
