### PR TITLE
ngx-active-reqs: fix the "semantic error: symbol without referent: id…

### DIFF
--- a/ngx-active-reqs
+++ b/ngx-active-reqs
@@ -428,7 +428,9 @@ $fin_code
 
         elapsed = local_clock_us() - begin
         printf("%d microseconds elapsed in the probe handler.\\n", elapsed)
-        if (nreqs || !$keep_waiting) {
+
+        keep_waiting = $keep_waiting
+        if (nreqs || !keep_waiting) {
             exit()
         }
     } /* $condition */


### PR DESCRIPTION
when run ngx-active-reqs by stap 4.0 without the "-k" option, it reports the following errors:
    semantic error: symbol without referent: identifier 'nreqs' at <input>:133:13
        source:         if (nreqs || !0) {
                            ^
so we can assign the $keep_waiting const to a var to fix it